### PR TITLE
chore: bump version to 1.12.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neilinger/businessmap-mcp",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "description": "Model Context Protocol server for BusinessMap (Kanbanize) integration",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Sync package.json version with v1.12.3 release tag.

This enables manual npm publish after CI test fixes.