### PR TITLE
fix(subtasks): pass instance parameter to correct BusinessMap endpoint

### DIFF
--- a/src/schemas/card-schemas.ts
+++ b/src/schemas/card-schemas.ts
@@ -257,6 +257,7 @@ export const createCardSubtaskSchema = z.object({
     )
     .optional()
     .describe('Attachments to add to the subtask'),
+  instance: SharedParams.shape.instance,
 });
 
 // Schemas complexos para criação de cards

--- a/src/server/tools/card-tools.ts
+++ b/src/server/tools/card-tools.ts
@@ -740,9 +740,8 @@ export class CardToolHandler implements BaseToolHandler {
       },
       async (params: any) => {
         try {
-          const { instance } = params;
+          const { instance, card_id, ...subtaskData } = params;
           const client = await getClientForInstance(clientOrFactory, instance);
-          const { card_id, ...subtaskData } = params;
           const subtask = await client.createCardSubtask(card_id, subtaskData);
           return createSuccessResponse(subtask, 'Subtask created successfully:');
         } catch (error) {

--- a/test/unit/server-tools/card-tools.test.ts
+++ b/test/unit/server-tools/card-tools.test.ts
@@ -973,6 +973,27 @@ describe('CardToolHandler', () => {
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain('Error creating card subtask');
     });
+
+    it('should exclude instance parameter from subtask data', async () => {
+      cardHandler.registerTools(mockServer, mockClient, false);
+      const handler = registeredTools.get('create_card_subtask');
+
+      mockClient.createCardSubtask.mockResolvedValue({ subtask_id: 100 });
+
+      await handler({
+        card_id: 1,
+        description: 'Subtask',
+        instance: 'test-instance',
+      });
+
+      expect(mockClient.createCardSubtask).toHaveBeenCalledWith(1, {
+        description: 'Subtask',
+      });
+      expect(mockClient.createCardSubtask).not.toHaveBeenCalledWith(
+        expect.any(Number),
+        expect.objectContaining({ instance: 'test-instance' })
+      );
+    });
   });
 
   describe('get_card_parents tool', () => {


### PR DESCRIPTION
## Summary

Fixes #33 - The `create_card_subtask` tool was ignoring the `instance` parameter, always sending requests to the default BusinessMap instance instead of the specified one.

**Impact**: 3 files changed (+23, -2) • **Risk Level**: 🟢 Low • **Review Time**: ~5 minutes

---

## Problem Statement

When using multi-instance configuration, calling `create_card_subtask` with an explicit `instance` parameter failed because:
1. The request was routed to the wrong BusinessMap instance
2. The API returned "card does not exist" since the card ID was valid only on the specified instance

### Reproduction Example
```
# Card 949 exists on 'kerkow' instance
get_card(card_id=949, instance="kerkow")           ✅ Success

# But subtask creation fails
create_card_subtask(card_id=949, instance="kerkow", description="Test")
                                                   ❌ "A card with id 949 does not exist"
```

---

## Root Cause Analysis

```mermaid
flowchart LR
    subgraph "❌ Before (Buggy)"
        A1["params = {instance, card_id, ...}"] --> B1["Extract: {instance}"]
        A1 --> C1["Extract: {card_id, ...subtaskData}"]
        C1 --> D1["subtaskData still contains instance!"]
        D1 --> E1["API receives invalid 'instance' field"]
    end
```

```mermaid
flowchart LR
    subgraph "✅ After (Fixed)"
        A2["params = {instance, card_id, ...}"] --> B2["Extract: {instance, card_id, ...subtaskData}"]
        B2 --> C2["instance → route to correct endpoint"]
        B2 --> D2["subtaskData → clean API payload"]
    end
```

### Two Issues Found

| Issue | Location | Problem |
|-------|----------|---------|
| Schema | `src/schemas/card-schemas.ts` | Missing `instance` field in `createCardSubtaskSchema` |
| Handler | `src/server/tools/card-tools.ts` | Destructured `instance` and `card_id` separately, leaving `instance` in `subtaskData` |

---

## Changes Made

### 1. Schema Fix (`src/schemas/card-schemas.ts`)
```diff
export const createCardSubtaskSchema = z.object({
  card_id: entityIdSchema.describe('The ID of the card'),
  description: descriptionSchema.describe('The description of the subtask'),
  // ... other fields
+ instance: SharedParams.shape.instance,
});
```

### 2. Handler Fix (`src/server/tools/card-tools.ts`)
```diff
async (params: any) => {
  try {
-   const { instance } = params;
+   const { instance, card_id, ...subtaskData } = params;
    const client = await getClientForInstance(clientOrFactory, instance);
-   const { card_id, ...subtaskData } = params;
    const subtask = await client.createCardSubtask(card_id, subtaskData);
```

### 3. Test Added (`test/unit/server-tools/card-tools.test.ts`)
```typescript
it('should exclude instance parameter from subtask data', async () => {
  // Verifies instance is NOT sent to API
  expect(mockClient.createCardSubtask).toHaveBeenCalledWith(1, {
    description: 'Subtask',
  });
  expect(mockClient.createCardSubtask).not.toHaveBeenCalledWith(
    expect.any(Number),
    expect.objectContaining({ instance: 'test-instance' })
  );
});
```

---

## Risk Assessment

| Factor | Score | Details |
|--------|-------|---------|
| Size | 🟢 1/10 | Only 3 files, 25 lines changed |
| Complexity | 🟢 1/10 | Simple destructuring fix |
| Test Coverage | 🟢 1/10 | New test specifically validates fix |
| Dependencies | 🟢 0/10 | No dependency changes |
| Breaking Changes | 🟢 0/10 | Backward compatible - fixes broken behavior |

**Overall Risk**: 🟢 **Low** - Minimal, focused fix with test coverage

---

## Test Results

| Test Suite | Result |
|------------|--------|
| Unit Tests | ✅ 444 passed, 1 skipped |
| TypeScript | ✅ No errors |
| ESLint | ✅ No new warnings |

### New Test Verification
```
✓ should exclude instance parameter from subtask data (card-tools.test.ts)
```

---

## Verification Steps

After merging, verify the fix works in multi-instance setup:

```bash
# 1. Configure multi-instance (kerkow + default)
# 2. Find a card on 'kerkow' instance
list_cards(board_id=15, instance="kerkow")

# 3. Create subtask on that card
create_card_subtask(
  card_id=949,
  instance="kerkow",
  description="Test subtask"
)
# Should now succeed ✅
```

---

## Review Checklist

### Code Quality
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No debugging code left
- [x] Follows existing patterns in codebase

### Testing
- [x] New test covers the fix
- [x] All existing tests pass
- [x] Test follows AAA pattern (Arrange, Act, Assert)

### Compatibility
- [x] No breaking changes
- [x] API behavior unchanged (except now works correctly)
- [x] Multi-instance and single-instance modes both work

---

## Related Issues

- Fixes #33 - `create_card_subtask` ignores instance parameter
- Related to multi-instance support added in v2.0.0