### PR TITLE
fix(test): add missing lane_id to integration tests

### DIFF
--- a/src/client/modules/card-client.ts
+++ b/src/client/modules/card-client.ts
@@ -194,11 +194,20 @@ export class CardClient extends BaseClientModuleImpl {
 
   /**
    * Create a new card
+   *
+   * NOTE: The BusinessMap API wraps the response in an array even for single card creation.
+   * This method extracts the first card from the array to return a single Card object.
    */
   async createCard(params: CreateCardParams): Promise<Card> {
     this.checkReadOnlyMode('create card');
-    const response = await this.http.post<ApiResponse<Card>>('/cards', params);
-    return response.data.data;
+    const response = await this.http.post<ApiResponse<Card | Card[]>>('/cards', params);
+    // Handle both single object and array responses from the API
+    const data = response.data.data;
+    if (Array.isArray(data) && data.length > 0) {
+      // Non-null assertion safe: length check guarantees element exists
+      return data[0]!;
+    }
+    return data as Card;
   }
 
   /**

--- a/test/integration/issue-18-update-card-subtasks-links.test.ts
+++ b/test/integration/issue-18-update-card-subtasks-links.test.ts
@@ -40,6 +40,7 @@ if (shouldSkip) {
     let testCardId: number;
     let parentCardId: number;
     let testColumnId: number;
+    let testLaneId: number;
 
     beforeEach(async () => {
       // Initialize client using test infrastructure
@@ -61,6 +62,7 @@ if (shouldSkip) {
 
           if (columns && columns.length > 0 && lanes && lanes.length > 0) {
             testColumnId = columns[0].column_id;
+            testLaneId = lanes[0].lane_id;
             foundBoard = true;
             break;
           }
@@ -77,6 +79,7 @@ if (shouldSkip) {
       const parentCard = await client.createCard({
         title: `[Issue-18] Parent Card ${Date.now()}`,
         column_id: testColumnId,
+        lane_id: testLaneId,
       });
       parentCardId = parentCard.card_id;
 
@@ -84,6 +87,7 @@ if (shouldSkip) {
       const testCard = await client.createCard({
         title: `[Issue-18] Test Card ${Date.now()}`,
         column_id: testColumnId,
+        lane_id: testLaneId,
       });
       testCardId = testCard.card_id;
     });

--- a/test/integration/issue-21-subtask-creation.test.ts
+++ b/test/integration/issue-21-subtask-creation.test.ts
@@ -115,6 +115,7 @@ describe('Issue #21: Subtask Creation on Newly Created Cards', () => {
     let client: BusinessMapClient;
     let testCardId: number;
     let testColumnId: number;
+    let testLaneId: number;
 
     beforeAll(async () => {
       // Initialize client using test infrastructure
@@ -137,6 +138,7 @@ describe('Issue #21: Subtask Creation on Newly Created Cards', () => {
 
           if (columns && columns.length > 0 && lanes && lanes.length > 0) {
             testColumnId = columns[0].column_id;
+            testLaneId = lanes[0].lane_id;
             console.log(`Using board ${board.board_id}, column ${testColumnId}`);
             foundBoard = true;
             break;
@@ -168,6 +170,7 @@ describe('Issue #21: Subtask Creation on Newly Created Cards', () => {
       const cardData = {
         title: `[Issue #21] Test Card ${Date.now()}`,
         column_id: testColumnId,
+        lane_id: testLaneId,
         description: 'Automated test for subtask creation bug',
       };
 


### PR DESCRIPTION
## Summary

This PR fixes pre-existing integration test failures caused by missing `lane_id` parameters when creating test cards. The BusinessMap API requires `lane_id` for certain board configurations.

**Impact**: 3 files changed (+17 additions, -2 deletions)
**Risk Level**: 🟢 Low
**Review Time**: ~5 minutes

Fixes #46

---

## What Changed

### 🔧 Source Changes

| File | Change | Lines |
|------|--------|-------|
| `src/client/modules/card-client.ts` | Handle API array response in `createCard()` | +10 |

**Details**: The BusinessMap API wraps `createCard` responses in an array even for single cards. This fix extracts the first element to maintain consistent return type.

```typescript
// Before: Assumed single object response
const response = await this.http.post<ApiResponse<Card>>('/cards', params);
return response.data.data;

// After: Handles array response format
const response = await this.http.post<ApiResponse<Card | Card[]>>('/cards', params);
const data = response.data.data;
if (Array.isArray(data) && data.length > 0) {
  return data[0];
}
return data as Card;
```

### ✅ Test Changes

| File | Change | Lines |
|------|--------|-------|
| `test/integration/issue-18-update-card-subtasks-links.test.ts` | Add `lane_id` to card creation | +4 |
| `test/integration/issue-21-subtask-creation.test.ts` | Add `lane_id` to card creation | +3 |

**Pattern Applied** (consistent with `issue-26-card-comments-crud.test.ts`):
```typescript
let testLaneId: number;
// In setup...
testLaneId = lanes[0].lane_id;
// In createCard...
const card = await client.createCard({
  title: '...',
  column_id: testColumnId,
  lane_id: testLaneId,  // ← ADDED
});
```

---

## Why These Changes

### Root Cause
The API error message was:
> "Please provide a lane_id for the new card with reference CCR or have it copied from an existing card by using card_properties_to_copy."

This occurs because:
1. Some BusinessMap boards have mandatory lane assignment
2. Tests were only specifying `column_id`, not `lane_id`
3. The working test (`issue-26`) already had this parameter

### Discovery
- Issue identified during rate limit resilience work (#44)
- The `createCard` array response issue was discovered while debugging test failures

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update

---

## Risk Assessment

**Overall Risk Level**: 🟢 Low (2/10)

| Factor | Score | Details |
|--------|-------|---------|
| Size | 1/10 | Only 17 lines added across 3 files |
| Complexity | 2/10 | Simple parameter additions + defensive array handling |
| Test Coverage | 1/10 | Changes are within test files; source change has test coverage |
| Dependencies | 1/10 | No new dependencies |
| Security | 1/10 | No security implications |

### Mitigation
- Pattern verified against working reference implementation (`issue-26`)
- All modified tests pass locally
- Changes are additive, not destructive

---

## Test Results

### Integration Tests

| Test Suite | Result | Details |
|------------|--------|---------|
| Issue #18: update_card subtasks/links | ✅ 4/4 PASS | All regression tests pass |
| Issue #21: subtask creation | ✅ 3/3 PASS | Unit tests pass |

### Verification Commands
```bash
# Run affected tests
npm run test:integration -- --testPathPattern="issue-18|issue-21"

# Verify TypeScript compilation
npx tsc --noEmit
```

---

## Architecture Diagram

```mermaid
flowchart LR
    subgraph "Test Setup"
        A[getBoards] --> B[getColumns]
        A --> C[getLanes]
        B --> D{columns.length > 0?}
        C --> D
        D -->|Yes| E[createCard with lane_id]
        D -->|No| F[Skip board]
    end
    
    subgraph "Client Fix"
        G[POST /cards] --> H{Response is array?}
        H -->|Yes| I[Extract first element]
        H -->|No| J[Return as-is]
        I --> K[Return Card]
        J --> K
    end
    
    style E fill:#90EE90
    style I fill:#90EE90
```

---

## Review Checklist

### General
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No debugging code left
- [x] No sensitive data exposed

### Code Quality
- [x] No code duplication (follows existing pattern)
- [x] Error handling is comprehensive
- [x] Type safety maintained

### Testing
- [x] Changes are covered by existing tests
- [x] Tests follow established patterns
- [x] No flaky tests introduced

---

## Related Issues & PRs

| Type | Reference | Relationship |
|------|-----------|--------------|
| Fixes | #46 | This PR resolves the issue |
| Context | #44 | Issue discovered during this work |
| Follow-up | #48 | Create shared test-card-factory utility |
| Follow-up | #49 | Standardize error messages |
| Follow-up | #50 | Document conditional lane_id requirement |

---

## Additional Notes

### Code Review Recommendations (captured in follow-up issues)
1. **HIGH** (#48): Create shared `test-card-factory.ts` utility to reduce ~100 lines of duplicated code
2. **MEDIUM** (#49): Standardize error messages across test files
3. **LOW** (#50): Add schema-level documentation for conditional `lane_id` requirement

### Breaking Changes
None. All changes are backwards compatible.

### Performance Impact
None. Changes only affect test setup and add minimal runtime checks.