### PR TITLE
docs(schema): document conditional lane_id requirement

### DIFF
--- a/src/schemas/bulk-schemas.ts
+++ b/src/schemas/bulk-schemas.ts
@@ -78,13 +78,24 @@ export const bulkUpdateBoardsSchemaShape = bulkUpdateBoardsBaseSchema.shape;
 // Bulk delete cards
 export const bulkDeleteCardsSchema = bulkDeleteBaseSchema;
 
-// Bulk update cards
+/**
+ * Bulk update cards schema
+ *
+ * Note: lane_id is optional but may be required by specific board configurations.
+ * Always fetch board structure before performing bulk moves to ensure compliance.
+ *
+ * @see get_lanes MCP tool to fetch available lanes for a board
+ * @see BusinessMapClient.getLanes() for programmatic access
+ */
 export const bulkUpdateCardsSchema = bulkUpdateBaseSchema
   .extend({
     title: optionalTitle.describe('New title for all cards'),
     description: optionalDescription.describe('New description for all cards'),
     column_id: optionalEntityId.describe('Move all cards to this column'),
-    lane_id: optionalEntityId.describe('Move all cards to this lane'),
+    lane_id: optionalEntityId.describe(
+      'Move all cards to this lane. Optional in schema but may be required by board configuration. ' +
+        'Use get_lanes tool or BusinessMapClient.getLanes() to fetch available lanes.'
+    ),
     priority: optionalPriority.describe('Priority level (0-10)'),
     owner_user_id: optionalEntityId.describe('Assign all cards to this user'),
   })

--- a/src/schemas/card-mutation-schemas.ts
+++ b/src/schemas/card-mutation-schemas.ts
@@ -286,7 +286,10 @@ export const updateCardSchema = z.object({
   title: optionalTitle,
   description: optionalDescription,
   column_id: optionalEntityId,
-  lane_id: optionalEntityId,
+  lane_id: optionalEntityId.describe(
+    'The ID of the lane where the card should be moved. Optional in schema but may be required by board configuration. ' +
+      'Use get_lanes tool or BusinessMapClient.getLanes() to fetch available lanes.'
+  ),
   position: optionalPosition,
   owner_user_id: optionalEntityId,
   assignee_user_id: optionalEntityId,
@@ -317,11 +320,21 @@ export const updateCardSchema = z.object({
 
 /**
  * Schema for moving a card to a different column/lane
+ *
+ * Note: lane_id is optional in schema but may be required by specific board configurations.
+ * Always fetch board structure before moving cards to ensure compliance with board setup.
+ *
+ * @see get_lanes MCP tool to fetch available lanes for a board
+ * @see BusinessMapClient.getLanes() for programmatic access
+ * @throws {ApiError} 400 - If board configuration requires lane_id but it's not provided
  */
 export const moveCardSchema = z.object({
   card_id: entityIdSchema.describe('The ID of the card to move'),
   column_id: entityIdSchema.describe('The target column ID'),
-  lane_id: optionalEntityId.describe('Optional target lane ID'),
+  lane_id: optionalEntityId.describe(
+    'Optional target lane ID. Optional in schema but may be required by board configuration. ' +
+      'Use get_lanes tool or BusinessMapClient.getLanes() to fetch available lanes for the board.'
+  ),
   position: optionalPosition.describe('Optional position in the column'),
   instance: SharedParams.shape.instance,
 });

--- a/src/schemas/common-schemas.ts
+++ b/src/schemas/common-schemas.ts
@@ -53,7 +53,8 @@ export const idArrayFilters = {
   })
     .optional()
     .describe(
-      'A list of the lane ids for which you want to get the results. Applied only if state parameter is active'
+      'A list of the lane IDs for which you want to filter results. Applied only if state parameter is active. ' +
+        'Note: lane_id values may be required by specific board configurations. Use get_lanes tool or BusinessMapClient.getLanes() to fetch available lanes.'
     ),
   workflow_ids: secureArray(entityIdSchema, {
     minItems: 0,

--- a/src/schemas/shared-params.ts
+++ b/src/schemas/shared-params.ts
@@ -64,11 +64,19 @@ export type SharedParamsType = z.infer<typeof SharedParams>;
 /**
  * Schema for card placement within lanes and positions
  *
- * @property lane_id - Optional lane identifier for card placement
+ * @property lane_id - Optional in schema but may be required by specific board configurations.
+ *   Always fetch board structure before creating cards to ensure compliance.
+ *   @see get_lanes MCP tool to fetch available lanes for a board
+ *   @see BusinessMapClient.getLanes() for programmatic access
+ *   @throws {ApiError} 400 - If board configuration requires lane_id but it's not provided
  * @property position - Optional position within the lane
  */
 export const PlacementSchema = z.object({
-  lane_id: entityIdSchema.optional().describe('The ID of the lane where the card should be placed'),
+  lane_id: entityIdSchema
+    .optional()
+    .describe(
+      'The ID of the lane where the card should be placed. Optional in schema but may be required by board configuration. Use get_lanes tool or BusinessMapClient.getLanes() to fetch available lanes.'
+    ),
   position: positionSchema
     .optional()
     .describe('The position of the card within the lane (0-based index)'),


### PR DESCRIPTION
## Summary

Closes #50 by documenting that `lane_id` is optional in schema validation but may be required by specific board configurations at runtime.

**Quick Stats**
| Metric | Value |
|--------|-------|
| Files Changed | 4 |
| Lines Added | +40 |
| Lines Removed | -7 |
| Risk Level | 🟢 Low (documentation only) |
| Review Time | ~5 minutes |

---

## Problem Addressed

The API returns this error for certain boards when `lane_id` is not provided:
```
"Please provide a lane_id for the new card with reference CCR or have it copied 
from an existing card by using card_properties_to_copy."
```

This creates a **schema vs. runtime validation gap**: schema validates ✅ → API rejects ❌

---

## What Changed

### 📝 Documentation Changes

| File | Schema | Change |
|------|--------|--------|
| `shared-params.ts` | `PlacementSchema` | Enhanced JSDoc with `@see` and `@throws` tags |
| `common-schemas.ts` | `idArrayFilters.lane_ids` | Added conditional requirement note |
| `card-mutation-schemas.ts` | `updateCardSchema`, `moveCardSchema` | Documented conditional lane_id behavior |
| `bulk-schemas.ts` | `bulkUpdateCardsSchema` | Added JSDoc with bulk operation guidance |

### Before/After Example

<details>
<summary>Click to expand code comparison</summary>

**Before** (`shared-params.ts:71`):
```typescript
lane_id: entityIdSchema.optional().describe('The ID of the lane where the card should be placed'),
```

**After**:
```typescript
/**
 * @property lane_id - Optional in schema but may be required by specific board configurations.
 *   @see get_lanes MCP tool to fetch available lanes for a board
 *   @see BusinessMapClient.getLanes() for programmatic access
 *   @throws {ApiError} 400 - If board configuration requires lane_id but it's not provided
 */
lane_id: entityIdSchema
  .optional()
  .describe(
    'The ID of the lane where the card should be placed. Optional in schema but may be required by board configuration. Use get_lanes tool or BusinessMapClient.getLanes() to fetch available lanes.'
  ),
```
</details>

---

## Documentation Pattern Applied

All updates follow a consistent pattern:

```typescript
/**
 * [Schema description]
 *
 * Note: lane_id is optional in schema but may be required by board configurations.
 *
 * @see get_lanes MCP tool to fetch available lanes for a board
 * @see BusinessMapClient.getLanes() for programmatic access
 * @throws {ApiError} 400 - If board configuration requires lane_id but not provided
 */
```

---

## Risk Assessment

| Factor | Score | Notes |
|--------|-------|-------|
| Size | 🟢 Low | 4 files, 40 insertions |
| Complexity | 🟢 None | Documentation only |
| Breaking Changes | 🟢 None | No functional changes |
| Test Impact | 🟢 None | No code changes to test |
| Security | 🟢 None | No security implications |

**Overall Risk**: 🟢 **Minimal** - Pure documentation improvement

---

## Testing

- [x] Documentation-only changes, no functional impact
- [x] Code review completed by code-reviewer agent
- [x] TypeScript syntax verified (manual review)
- [ ] Lint check (pending CI)
- [ ] Build check (pending CI)

---

## Review Checklist

### General
- [x] Documentation is clear and accurate
- [x] JSDoc tags are properly formatted
- [x] Tool/method references are correct
- [x] Consistent pattern across all files

### Reviewer Focus Areas
1. **Accuracy**: Does documentation match actual API behavior?
2. **Completeness**: Are all relevant `lane_id` locations documented?
3. **Clarity**: Is the conditional requirement clearly explained?
4. **Consistency**: Same pattern applied everywhere?

---

## Files Not Modified (intentional)

| File | Reason |
|------|--------|
| `board-schemas.ts` | `getLaneSchema` is read-only, conditional requirement doesn't apply |
| `card-query-schemas.ts` | `last_lane_ids` is for historical filtering, not card creation |

---

## Related

- **Issue**: #50
- **Identified in**: Code review for #46 (PR #47)
- **Priority**: Low - Documentation improvement