### PR TITLE
chore: ignore graphify output artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ docs/architecture/
 # ACE local cache (SQLite database)
 .ace-cache/
 .worktree/
+graphify-out/


### PR DESCRIPTION
## Summary

Graphify can now write local output under `graphify-out/` without surfacing generated artifacts as repository changes. This is repo hygiene only: no source, runtime, package-lock, or `.specify` changes are included.

## Validation

- `git status --porcelain=v1 --untracked-files=all` showed only `M .gitignore` before commit and a clean worktree after commit.
- `git diff --name-status origin/main...HEAD` reports only `M .gitignore`.
- `git diff --check origin/main...HEAD` exits 0.
- `git check-ignore -v graphify-out/sentinel.txt` resolves to `.gitignore:140:graphify-out/`.
- Accepted artifact hash verified: `tracked-working.diff` = `d27bc7975fed486087abf698ceeb55c6f4b3f20111b9a74931ce94c5315ed29d`.

## Release boundary

Review-only PR. I did not merge, tag, release, publish to npm, deploy, install for a customer, or mutate BusinessMap live APIs.

## Related

- Hermes Kanban: `t_cef3c5cc`, `t_f6b33853`, `t_8c68156f`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5.5](https://img.shields.io/badge/GPT_5.5-000000)
